### PR TITLE
Render only enabled services in homepage

### DIFF
--- a/homelab/services/homepage/default.nix
+++ b/homelab/services/homepage/default.nix
@@ -116,7 +116,7 @@ in
           homepageServices =
             x:
             (lib.attrsets.filterAttrs (
-              name: value: value ? homepage && value.homepage.category == x
+              name: value: value ? enable && value.enable && value ? homepage && value.homepage.category == x
             ) homelab.services);
         in
         lib.lists.forEach homepageCategories (cat: {


### PR DESCRIPTION
This might not be what you want, but this fix makes sure a service only shows up on the homepage if it's activated.