### PR TITLE
Small improvements wireguard-netns

### DIFF
--- a/homelab/services/wireguard-netns/default.nix
+++ b/homelab/services/wireguard-netns/default.nix
@@ -5,8 +5,8 @@
   ...
 }:
 let
-  hl = config.homelab;
-  cfg = hl.services.wireguard-netns;
+  homelab = config.homelab;
+  cfg = homelab.services.wireguard-netns;
 in
 {
   options.homelab.services.wireguard-netns = {
@@ -24,9 +24,7 @@ in
       example = lib.literalExpression ''
         pkgs.writeText "wg0.conf" '''
           [Interface]
-          Address = 192.168.2.2
           PrivateKey = <client's privatekey>
-          ListenPort = 21841
 
           [Peer]
           PublicKey = <server's publickey>
@@ -71,7 +69,7 @@ in
             ${iproute2}/bin/ip link set wg0 netns ${cfg.namespace}
             ${iproute2}/bin/ip -n ${cfg.namespace} address add ${cfg.privateIP} dev wg0
             ${iproute2}/bin/ip netns exec ${cfg.namespace} \
-            ${pkgs.wireguard-tools}/bin/wg setconf wg0 ${cfg.configFile}
+            ${wireguard-tools}/bin/wg setconf wg0 ${cfg.configFile}
             ${iproute2}/bin/ip -n ${cfg.namespace} link set wg0 up
             ${iproute2}/bin/ip -n ${cfg.namespace} link set lo up
             ${iproute2}/bin/ip -n ${cfg.namespace} route add default dev wg0


### PR DESCRIPTION
- Using homelab instead of hl for consistency with other modules
- Fixing the example for configFile (since current one will not work)
- Using pkgs from with on wireguard-tool
