### PR TITLE
Use dns from vpn client

### DIFF
--- a/modules/homelab/services/deluge/default.nix
+++ b/modules/homelab/services/deluge/default.nix
@@ -68,7 +68,10 @@ in
         "network-online.target"
         "${ns}.service"
       ];
-      services.deluged.serviceConfig.NetworkNamespacePath = [ "/var/run/netns/${ns}" ];
+      services.deluged.serviceConfig = {
+        NetworkNamespacePath = [ "/var/run/netns/${ns}" ];
+        BindReadOnlyPaths = "/etc/netns/${ns}/resolv.conf:/etc/resolv.conf";
+      };
       sockets."deluged-proxy" = {
         enable = true;
         description = "Socket for Proxy to Deluge WebUI";


### PR DESCRIPTION
https://github.com/notthebee/nix-config/blob/72b717a6a83b147f9f7645a6b833bcb2f8321abe/modules/homelab/services/wireguard-netns/default.nix#L53

This `resolv.conf` file created for a separate namespace is not used by service because `NetworkNamespacePath` only makes systemd to switch network namespace but it doesn't mount any paths. To use a namespace's specific DNS configuration in a service the file should be mounted explicitly.
https://serverfault.com/a/1123523
